### PR TITLE
Add deps.edn and suppress warnings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src" "resources"],
+ :deps {ordered/ordered {:mvn/version "1.3.2"}}}

--- a/src/php_clj/core.clj
+++ b/src/php_clj/core.clj
@@ -3,6 +3,7 @@
 ;; http://www.eclipse.org/legal/epl-v10.html
 
 (ns php_clj.core
+  (:refer-clojure :exclude [parse-double parse-boolean])
   (:require [php_clj.reader :as r]
             [clojure.string :as s]
             [ordered.map :refer [ordered-map]]))


### PR DESCRIPTION
Yes, I am that guy who still uses this library :)

I see there were no commits for the last 12 years (that's what I like in Clojure ecosystem) and I am not sure if you want to be bothered with this PR. If not — no worries, feel free to close it.

A couple warnings were bugging me, so I decided to clean them up.

```WARNING: parse-double already refers to: #'clojure.core/parse-double in namespace: php_clj.core, being replaced by: #'php_clj.core/parse-double  ```

```WARNING: parse-boolean already refers to: #'clojure.core/parse-boolean in namespace: php_clj.core, being replaced by: #'php_clj.core/parse-boolean```
